### PR TITLE
Fix two torch warnings

### DIFF
--- a/RealESRGAN/model.py
+++ b/RealESRGAN/model.py
@@ -56,7 +56,7 @@ class RealESRGAN:
         self.model.eval()
         self.model.to(self.device)
         
-    @torch.cuda.amp.autocast()
+    @torch.amp.autocast(device_type='cuda')
     def predict(self, lr_image, batch_size=4, patches_size=192,
                 padding=24, pad_size=15):
         scale = self.scale

--- a/RealESRGAN/model.py
+++ b/RealESRGAN/model.py
@@ -46,7 +46,7 @@ class RealESRGAN:
             cached_download(config_file_url, cache_dir=cache_dir, force_filename=local_filename)
             print('Weights downloaded to:', os.path.join(cache_dir, local_filename))
         
-        loadnet = torch.load(model_path)
+        loadnet = torch.load(model_path, weights_only=True)
         if 'params' in loadnet:
             self.model.load_state_dict(loadnet['params'], strict=True)
         elif 'params_ema' in loadnet:


### PR DESCRIPTION
When using this module, two warnings are displayed:

> ./python3.12/site-packages/RealESRGAN/model.py:59: FutureWarning: `torch.cuda.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cuda', args...)` instead.


>   @torch.cuda.amp.autocast()
> ./python3.12/site-packages/RealESRGAN/model.py:49: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.

This PR fixes those warnings with two simple changes in model.py:

* Instead of using the deprecated `@torch.cuda.amp.autocast()` use: `@torch.amp.autocast(device_type='cuda')`
   * #14 addresses this a different way which might be better for non-CUDA device support
* The `torch.load()` call now passes `weights_only=True` to address code-execution risks during serialization
   * I don't know these models well enough to know if this will break anything, but in my local tests it seems to work fine
   
Feel free to close this if it doesn't meet the projects standards or is already being addressed elsewhere.  I'm sharing in case it is useful to others.
