### PR TITLE
Fix #35 error due to breaking change in hugging face dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ Pillow
 torch>=1.7
 torchvision>=0.8.0
 tqdm
-huggingface-hub
+huggingface-hub==0.25.2


### PR DESCRIPTION
When instantiating `RealESRGAN` object with the latest huggingface-hub version, an `ImportError` is raised as `cached_download` was deprecated. This PR fixes the huggingface dependency to `0.25.2` version.