### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ Pillow
 torch>=1.7
 torchvision>=0.8.0
 tqdm
-huggingface-hub
+huggingface-hub==0.25.2


### PR DESCRIPTION
`huggingface-hub` removes `cached_download` in 0.26. This should probably be updated to use a newer version of the dependency, but for now, this will fix the example code